### PR TITLE
Alpha and resize

### DIFF
--- a/Test/Base.lproj/Main.storyboard
+++ b/Test/Base.lproj/Main.storyboard
@@ -52,7 +52,7 @@
                                                             <rect key="frame" x="0.0" y="0.0" width="414" height="100"/>
                                                             <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                                             <constraints>
-                                                                <constraint firstAttribute="height" constant="100" id="1DY-SL-cEY"/>
+                                                                <constraint firstAttribute="height" priority="999" constant="100" id="1DY-SL-cEY"/>
                                                             </constraints>
                                                             <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur. Excepteur sint occaecat cupidatat non proident, sunt in culpa qui officia deserunt mollit anim id est laborum. Nam liber te conscient to factor tum poen legum odioque civiuda.</string>
                                                             <color key="textColor" systemColor="labelColor" cocoaTouchSystemColor="darkTextColor"/>

--- a/Test/TableViewCell.swift
+++ b/Test/TableViewCell.swift
@@ -10,29 +10,37 @@ import UIKit
 
 class TableViewCell: UITableViewCell {
 
-
     @IBOutlet var theTextView: UITextView!
     @IBOutlet var hiddenCon: NSLayoutConstraint!
+    
     override func awakeFromNib() {
         super.awakeFromNib()
-        // Initialization code
-    }
-    
-    var tableUpdateCallback: (()->())?
-
-    override func setSelected(_ selected: Bool, animated: Bool) {
-        super.setSelected(selected, animated: animated)
-
-        // Configure the view for the selected state
+        selectionStyle = .none
     }
 
-    func grow() {
-        UIView.animate(withDuration: 0.5) {
-            self.theTextView.alpha = 0.0
-            self.hiddenCon.constant = 0
-            self.contentView.layoutIfNeeded()
-            self.tableUpdateCallback?()
+    func configure(for state: HiddenState) {
+        switch state {
+        case .hidden:
+            theTextView.alpha = 0
+            hiddenCon.constant = 0
+
+        case .visible:
+            theTextView.alpha = 1
+            hiddenCon.constant = 100
+
+        case .hiding:
+            theTextView.alpha = 1
+            hiddenCon.constant = 0
+            UIView.animate(withDuration: 0.25, delay: 0, options: .allowUserInteraction, animations: {
+                self.theTextView.alpha = 0
+            })
+
+        case .unhiding:
+            theTextView.alpha = 0
+            hiddenCon.constant = 100
+            UIView.animate(withDuration: 0.25, delay: 0, options: .allowUserInteraction, animations: {
+                self.theTextView.alpha = 1
+            })
         }
     }
-
 }

--- a/Test/TableViewController.swift
+++ b/Test/TableViewController.swift
@@ -8,99 +8,62 @@
 
 import UIKit
 
+enum HiddenState {
+    case hidden
+    case visible
+    case hiding
+    case unhiding
+}
+
+struct MyObject {
+    var state: HiddenState
+}
+
 class TableViewController: UITableViewController {
 
-    override func viewDidLoad() {
-        super.viewDidLoad()
+    var objects = (0..<25).map { _ in MyObject(state: .visible) }
 
-        // Uncomment the following line to preserve selection between presentations
-        // self.clearsSelectionOnViewWillAppear = false
+}
 
-        // Uncomment the following line to display an Edit button in the navigation bar for this view controller.
-        // self.navigationItem.rightBarButtonItem = self.editButtonItem
+// MARK: - UITableViewDataSource
 
-    }
-
-    // MARK: - Table view data source
-
-    override func numberOfSections(in tableView: UITableView) -> Int {
-        // #warning Incomplete implementation, return the number of sections
-        return 1
-    }
+extension TableViewController {
 
     override func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        // #warning Incomplete implementation, return the number of rows
-        return 25
+        return objects.count
     }
-
-
 
     override func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell = tableView.dequeueReusableCell(withIdentifier: "cell", for: indexPath) as! TableViewCell
-        cell.selectionStyle = .none
 
-        cell.tableUpdateCallback = {
-            tableView.beginUpdates()
-            tableView.endUpdates()
+        let state = objects[indexPath.row].state
+
+        cell.configure(for: state)
+
+        switch state {
+        case .hiding: objects[indexPath.row].state = .hidden
+        case .unhiding: objects[indexPath.row].state = .visible
+        default: break
         }
-
 
         return cell
     }
+}
+
+// MARK: - UITableViewDelegate
+
+extension TableViewController {
 
     override func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
+        switch objects[indexPath.row].state {
+        case .hidden, .hiding:
+            objects[indexPath.row].state = .unhiding
 
-        let cell = tableView.cellForRow(at: indexPath) as? TableViewCell
+        case .visible, .unhiding:
+            objects[indexPath.row].state = .hiding
+        }
 
-        
-        cell?.grow()
-
+        tableView.reloadRows(at: [indexPath], with: .fade)
     }
-
-
-    /*
-    // Override to support conditional editing of the table view.
-    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
-        // Return false if you do not want the specified item to be editable.
-        return true
-    }
-    */
-
-    /*
-    // Override to support editing the table view.
-    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
-        if editingStyle == .delete {
-            // Delete the row from the data source
-            tableView.deleteRows(at: [indexPath], with: .fade)
-        } else if editingStyle == .insert {
-            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
-        }    
-    }
-    */
-
-    /*
-    // Override to support rearranging the table view.
-    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
-
-    }
-    */
-
-    /*
-    // Override to support conditional rearranging of the table view.
-    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
-        // Return false if you do not want the item to be re-orderable.
-        return true
-    }
-    */
-
-    /*
-    // MARK: - Navigation
-
-    // In a storyboard-based application, you will often want to do a little preparation before navigation
-    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
-        // Get the new view controller using segue.destination.
-        // Pass the selected object to the new view controller.
-    }
-    */
 
 }


### PR DESCRIPTION
This isn't quite what you're looking for, but it's as close as I could get. So, a few observations:

1. The “is it hidden or not” should be in your model, not just the cell. (When you scroll and a cell is reused, you should be referring to the model to know when a cell's text view is hidden or not.)

2. The view controller therefore maintains the model, and just calls `reloadRows(at:with:)`, which triggers `cellForRowAt` to be called.

3. The cell will take care of animations within that cell. The `cellForRowAt` generally shouldn't be reaching inside the cell and messing around with its controls. That's the cell's job, in the spirit of the SRP.

4. I would not rely on the `beginUpdates`/`endUpdates` (with no updates in-between these two calls) pattern. This is relying upon undocumented behavior of table views and is subject to change at any time. The purpose of this API is to say "hey, I inserted rows 3 and 4 and deleted rows 7 and 8, but I want to do that as part of a single transaction."

5. I lowered the priority of the height constraint from 1000 to 999 to avoid auto-layout warnings.